### PR TITLE
Add example API data folder for testing/dev purposes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+API_BASE_URL='https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/'
+AUTH=
+SERVER_PORT=

--- a/examples/cart.js
+++ b/examples/cart.js
@@ -1,0 +1,3 @@
+
+// GET /cart
+module.exports.cart = []

--- a/examples/generateExampleData.js
+++ b/examples/generateExampleData.js
@@ -1,0 +1,78 @@
+/*
+This script saves example API call for each endpoint to corresponding
+files in the /examples directory.
+*/
+require('dotenv').config();
+
+const fs = require('fs');
+const path = require('path');
+const axios = require('axios');
+
+const BASE_URL = 'https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/';
+
+class Endpoint {
+  constructor(category, name, endpoint, description) {
+    this.category = category;
+    this.name = name;
+    this.endpoint = endpoint;
+    this.description = description;
+  }
+}
+
+const endpoints = [
+                         // name , category, endpoint, description
+  // Products
+  new Endpoint('products', 'products', 'products', 'GET /products'),
+  new Endpoint('products', 'information', 'products/40344', 'GET /products/:product_id'),
+  new Endpoint('products', 'styles', 'products/40344/styles', 'GET /products/:product_id/styles'),
+  new Endpoint('products', 'related', 'products/40344/related', 'GET /products/:product_id/related'),
+
+  // Reviews
+  new Endpoint('reviews', 'reviews', 'reviews?product_id=40344', 'GET /reviews'),
+  new Endpoint('reviews', 'meta', 'reviews/meta?product_id=40344', 'GET /reviews/meta'),
+
+  // Questions and answers
+  new Endpoint('questionsAndAnswers', 'questions', 'qa/questions?product_id=40344', 'GET /qa/questions'),
+  new Endpoint('questionsAndAnswers', 'answers', 'qa/questions/40344/answers', 'GET /qa/questions/:question_id/answers'),
+
+  // Cart
+  new Endpoint('cart', 'cart', 'cart', 'GET /cart')
+]
+
+console.log('Cleaning up examples directory...');
+
+endpoints.forEach(async endpoint => {
+  let file = path.join('examples', endpoint.category + '.js');
+    try {
+        await fs.promises.unlink(file);
+    } catch (error) {
+      // Files already deleted will throw an error, so this catches that.
+    }
+});
+
+console.log('Requesting data...')
+
+endpoints.forEach(async endpoint => {
+    let url = BASE_URL + endpoint.endpoint;
+    console.log(url);
+
+    let file = path.join('examples', endpoint.category + '.js');
+    let varName = endpoint.name;
+    let description = endpoint.description;
+
+    try {
+      let response = await axios({
+        url: url,
+        headers: {'Authorization': process.env.AUTH}
+      });
+
+      let contents = `\n// ${description}\nmodule.exports.${varName} = ${JSON.stringify(response.data, null, 2)}\n`
+      await fs.promises.appendFile(file, contents);
+
+    } catch (error) {
+      console.log(`Error on: ${url}`)
+      console.log(error);
+    }
+})
+
+console.log('Finished.')

--- a/examples/products.js
+++ b/examples/products.js
@@ -1,0 +1,451 @@
+
+// GET /products
+module.exports.products = [
+  {
+    "id": 40344,
+    "campus": "hr-rfp",
+    "name": "Camo Onesie",
+    "slogan": "Blend in to your crowd",
+    "description": "The So Fatigues will wake you up and fit you in. This high energy camo will have you blending in to even the wildest surroundings.",
+    "category": "Jackets",
+    "default_price": "140.00",
+    "created_at": "2021-08-13T14:38:44.509Z",
+    "updated_at": "2021-08-13T14:38:44.509Z"
+  },
+  {
+    "id": 40345,
+    "campus": "hr-rfp",
+    "name": "Bright Future Sunglasses",
+    "slogan": "You've got to wear shades",
+    "description": "Where you're going you might not need roads, but you definitely need some shades. Give those baby blues a rest and let the future shine bright on these timeless lenses.",
+    "category": "Accessories",
+    "default_price": "69.00",
+    "created_at": "2021-08-13T14:38:44.509Z",
+    "updated_at": "2021-08-13T14:38:44.509Z"
+  },
+  {
+    "id": 40346,
+    "campus": "hr-rfp",
+    "name": "Morning Joggers",
+    "slogan": "Make yourself a morning person",
+    "description": "Whether you're a morning person or not.  Whether you're gym bound or not.  Everyone looks good in joggers.",
+    "category": "Pants",
+    "default_price": "40.00",
+    "created_at": "2021-08-13T14:38:44.509Z",
+    "updated_at": "2021-08-13T14:38:44.509Z"
+  },
+  {
+    "id": 40347,
+    "campus": "hr-rfp",
+    "name": "Slacker's Slacks",
+    "slogan": "Comfortable for everything, or nothing",
+    "description": "I'll tell you how great they are after I nap for a bit.",
+    "category": "Pants",
+    "default_price": "65.00",
+    "created_at": "2021-08-13T14:38:44.509Z",
+    "updated_at": "2021-08-13T14:38:44.509Z"
+  },
+  {
+    "id": 40348,
+    "campus": "hr-rfp",
+    "name": "Heir Force Ones",
+    "slogan": "A sneaker dynasty",
+    "description": "Now where da boxes where I keep mine? You should peep mine, maybe once or twice but never three times. I'm just a sneaker pro, I love Pumas and shell toes, but can't nothin compare to a fresh crispy white pearl",
+    "category": "Kicks",
+    "default_price": "99.00",
+    "created_at": "2021-08-13T14:38:44.509Z",
+    "updated_at": "2021-08-13T14:38:44.509Z"
+  }
+]
+
+// GET /products/:product_id/styles
+module.exports.styles = {
+  "product_id": "40344",
+  "results": [
+    {
+      "style_id": 240500,
+      "name": "Forest Green & Black",
+      "original_price": "140.00",
+      "sale_price": null,
+      "default?": true,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1534011546717-407bced4d25c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1534011546717-407bced4d25c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2734&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1549831243-a69a0b3d39e0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1549831243-a69a0b3d39e0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2775&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1527522883525-97119bfce82d?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1527522883525-97119bfce82d?ixlib=rb-1.2.1&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1556648202-80e751c133da?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1556648202-80e751c133da?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1532543491484-63e29b3c1f5d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1532543491484-63e29b3c1f5d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
+        }
+      ],
+      "skus": {
+        "1394769": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394770": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394771": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394772": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394773": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394774": {
+          "quantity": 4,
+          "size": "XL"
+        }
+      }
+    },
+    {
+      "style_id": 240501,
+      "name": "Desert Brown & Tan",
+      "original_price": "140.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1533779183510-8f55a55f15c1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1533779183510-8f55a55f15c1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1560567546-4c6dbc16877b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1560567546-4c6dbc16877b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1458253329476-1ebb8593a652?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1458253329476-1ebb8593a652?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1422557379185-474fa15bf770?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1422557379185-474fa15bf770?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1490723286627-4b66e6b2882a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1490723286627-4b66e6b2882a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1447958272669-9c562446304f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1447958272669-9c562446304f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2800&q=80"
+        }
+      ],
+      "skus": {
+        "1394775": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394776": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394777": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394778": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394779": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394780": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240502,
+      "name": "Ocean Blue & Grey",
+      "original_price": "140.00",
+      "sale_price": "100.00",
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1556304653-cba65c59b3c5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1556304653-cba65c59b3c5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2761&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1544131750-2985d621da30?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1544131750-2985d621da30?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=666&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1557760257-b02421ae77fe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1557760257-b02421ae77fe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2089&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1551506448-074afa034c05?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1551506448-074afa034c05?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=938&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1556268652-ad74ebb8f1e7?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1556268652-ad74ebb8f1e7?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1557394976-32cc983558ba?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1557394976-32cc983558ba?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
+        }
+      ],
+      "skus": {
+        "1394781": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394782": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394783": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394784": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394785": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394786": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240503,
+      "name": "Digital Red & Black",
+      "original_price": "140.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1530092376999-2431865aa8df?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1530092376999-2431865aa8df?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2734&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1487174244970-cd18784bb4a4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1487174244970-cd18784bb4a4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1652&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1488554378835-f7acf46e6c98?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1488554378835-f7acf46e6c98?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1486025402772-bc179c8dfb0e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1486025402772-bc179c8dfb0e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1473691955023-da1c49c95c78?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1473691955023-da1c49c95c78?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1517456837005-d757b959ae2b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=60",
+          "url": "https://images.unsplash.com/photo-1517456837005-d757b959ae2b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60"
+        }
+      ],
+      "skus": {
+        "1394787": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394788": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394789": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394790": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394791": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394792": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240504,
+      "name": "Sky Blue & White",
+      "original_price": "140.00",
+      "sale_price": "100.00",
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1448526478325-616f2b15b04e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1448526478325-616f2b15b04e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1567&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1519098635131-4c8f806d1e82?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1519098635131-4c8f806d1e82?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1483056293146-9eac9521932f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1483056293146-9eac9521932f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1515992854631-13de43baeba1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1515992854631-13de43baeba1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1525141741567-f89ef016dfeb?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1525141741567-f89ef016dfeb?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1418985991508-e47386d96a71?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1418985991508-e47386d96a71?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        }
+      ],
+      "skus": {
+        "1394793": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394794": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394795": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394796": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394797": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394798": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240505,
+      "name": "Dark Grey & Black",
+      "original_price": "170.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1514866726862-0f081731e63f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1514866726862-0f081731e63f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1519689373023-dd07c7988603?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1519689373023-dd07c7988603?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1506932248762-69d978912b80?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1506932248762-69d978912b80?ixlib=rb-1.2.1&auto=format&fit=crop&w=2089&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1535639818669-c059d2f038e6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1535639818669-c059d2f038e6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1498098662025-04e60a212db4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1498098662025-04e60a212db4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1421941027568-40ab08ee5592?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1421941027568-40ab08ee5592?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80"
+        }
+      ],
+      "skus": {
+        "1394799": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394800": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394801": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394802": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394803": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394804": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    }
+  ]
+}
+
+// GET /products/:product_id/related
+module.exports.related = [
+  40345,
+  40346,
+  40351,
+  40350
+]
+
+// GET /products/:product_id
+module.exports.information = {
+  "id": 40344,
+  "campus": "hr-rfp",
+  "name": "Camo Onesie",
+  "slogan": "Blend in to your crowd",
+  "description": "The So Fatigues will wake you up and fit you in. This high energy camo will have you blending in to even the wildest surroundings.",
+  "category": "Jackets",
+  "default_price": "140.00",
+  "created_at": "2021-08-13T14:38:44.509Z",
+  "updated_at": "2021-08-13T14:38:44.509Z",
+  "features": [
+    {
+      "feature": "Fabric",
+      "value": "Canvas"
+    },
+    {
+      "feature": "Buttons",
+      "value": "Brass"
+    }
+  ]
+}

--- a/examples/questionsAndAnswers.js
+++ b/examples/questionsAndAnswers.js
@@ -1,0 +1,101 @@
+
+// GET /qa/questions
+module.exports.questions = {
+  "product_id": "40344",
+  "results": [
+    {
+      "question_id": 593082,
+      "question_body": "Would it fit super skinny people?",
+      "question_date": "2022-04-12T00:00:00.000Z",
+      "asker_name": "Man",
+      "question_helpfulness": 23,
+      "reported": false,
+      "answers": {
+        "5539005": {
+          "id": 5539005,
+          "body": "Probably Not",
+          "date": "2022-04-12T00:00:00.000Z",
+          "answerer_name": "user",
+          "helpfulness": 2,
+          "photos": []
+        },
+        "5539007": {
+          "id": 5539007,
+          "body": "Yes",
+          "date": "2022-04-12T00:00:00.000Z",
+          "answerer_name": "User",
+          "helpfulness": 2,
+          "photos": []
+        },
+        "5539010": {
+          "id": 5539010,
+          "body": "Absolutely",
+          "date": "2022-04-12T00:00:00.000Z",
+          "answerer_name": "User",
+          "helpfulness": 0,
+          "photos": []
+        },
+        "5539011": {
+          "id": 5539011,
+          "body": "Absolutely Not",
+          "date": "2022-04-12T00:00:00.000Z",
+          "answerer_name": "User",
+          "helpfulness": 0,
+          "photos": []
+        },
+        "5539012": {
+          "id": 5539012,
+          "body": "Most likely not",
+          "date": "2022-04-12T00:00:00.000Z",
+          "answerer_name": "User",
+          "helpfulness": 0,
+          "photos": []
+        },
+        "5539085": {
+          "id": 5539085,
+          "body": "Can't say for sure",
+          "date": "2022-04-13T00:00:00.000Z",
+          "answerer_name": "RandomUser",
+          "helpfulness": 0,
+          "photos": []
+        },
+        "5539088": {
+          "id": 5539088,
+          "body": "I sure hope so!",
+          "date": "2022-04-13T00:00:00.000Z",
+          "answerer_name": "User",
+          "helpfulness": 0,
+          "photos": []
+        },
+        "5985304": {
+          "id": 5985304,
+          "body": "Im the captain now",
+          "date": "2022-05-16T00:00:00.000Z",
+          "answerer_name": "Seller",
+          "helpfulness": 0,
+          "photos": []
+        },
+        "5985305": {
+          "id": 5985305,
+          "body": "6",
+          "date": "2022-05-16T00:00:00.000Z",
+          "answerer_name": "yasi",
+          "helpfulness": 0,
+          "photos": [
+            "https://res.cloudinary.com/dwbhfydeg/image/upload/v1652667312/flareon_tvuj2x.jpg",
+            "https://res.cloudinary.com/dwbhfydeg/image/upload/v1652667313/vaporean_qpa1jv.jpg",
+            "https://res.cloudinary.com/dwbhfydeg/image/upload/v1652667311/jolteon_w9epbj.jpg"
+          ]
+        }
+      }
+    }
+  ]
+}
+
+// GET /qa/questions/:question_id/answers
+module.exports.answers = {
+  "question": "40344",
+  "page": 1,
+  "count": 5,
+  "results": []
+}

--- a/examples/reviews.js
+++ b/examples/reviews.js
@@ -1,0 +1,103 @@
+
+// GET /reviews
+module.exports.reviews = {
+  "product": "40344",
+  "page": 0,
+  "count": 5,
+  "results": [
+    {
+      "review_id": 1135681,
+      "rating": 5,
+      "summary": "OMG it works",
+      "recommend": true,
+      "response": null,
+      "body": "That's pretty dang cool that a review can be posted through this modal",
+      "date": "2022-02-19T00:00:00.000Z",
+      "reviewer_name": "Richard",
+      "helpfulness": 93,
+      "photos": []
+    },
+    {
+      "review_id": 1135837,
+      "rating": 3,
+      "summary": "hhi",
+      "recommend": true,
+      "response": null,
+      "body": "hi",
+      "date": "2022-02-22T00:00:00.000Z",
+      "reviewer_name": "Hello",
+      "helpfulness": 5,
+      "photos": []
+    },
+    {
+      "review_id": 1135738,
+      "rating": 3,
+      "summary": "this is monks test",
+      "recommend": true,
+      "response": null,
+      "body": "it fits me perfectly",
+      "date": "2022-02-20T00:00:00.000Z",
+      "reviewer_name": "monks",
+      "helpfulness": 1,
+      "photos": []
+    },
+    {
+      "review_id": 1135846,
+      "rating": 2,
+      "summary": "sdfds",
+      "recommend": true,
+      "response": null,
+      "body": "sdfdsf",
+      "date": "2022-02-22T00:00:00.000Z",
+      "reviewer_name": "sdfsdf",
+      "helpfulness": 0,
+      "photos": []
+    },
+    {
+      "review_id": 1135833,
+      "rating": 3,
+      "summary": "test",
+      "recommend": false,
+      "response": null,
+      "body": "test",
+      "date": "2022-02-22T00:00:00.000Z",
+      "reviewer_name": "test",
+      "helpfulness": 0,
+      "photos": []
+    }
+  ]
+}
+
+// GET /reviews/meta
+module.exports.meta = {
+  "product_id": "40344",
+  "ratings": {
+    "1": "45",
+    "2": "43",
+    "3": "103",
+    "4": "99",
+    "5": "247"
+  },
+  "recommended": {
+    "false": "136",
+    "true": "401"
+  },
+  "characteristics": {
+    "Fit": {
+      "id": 135219,
+      "value": "3.0433333333333333"
+    },
+    "Length": {
+      "id": 135220,
+      "value": "3.0333333333333333"
+    },
+    "Comfort": {
+      "id": 135221,
+      "value": "3.2823920265780731"
+    },
+    "Quality": {
+      "id": 135222,
+      "value": "3.4272445820433437"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.2.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^0.27.2",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",
     "nodemon": "^2.0.16",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "server": "nodemon server/index.js",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "gen-examples": "node examples/generateExampleData.js"
   },
   "eslintConfig": {
     "extends": [

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,11 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import './App.css';
 import ProductList from './ProductList.jsx';
+import './styles/Styles.css';
 
 function App() {
   return (
-    <div className="App">
+    <div className="page-wrapper">
+
       <ProductList />
       <Link to="/details">Product Details</Link>
     </div>

--- a/src/components/ProductDetail.jsx
+++ b/src/components/ProductDetail.jsx
@@ -20,6 +20,9 @@ class ProductDetail extends React.Component {
         <RelatedProducts />
         <QuestionsAnswers />
         <Reviews />
+
+
+
       </div>
 
     )

--- a/src/components/ProductOverview.jsx
+++ b/src/components/ProductOverview.jsx
@@ -1,11 +1,402 @@
 import React from 'react';
+//import { useFetch } from '../../lib/useFecth.js';
 
 const ProductOverview = () => {
+
+  //const { styles } = useFecth(`https://app-hrsei-api.herokuapp.com/api/fec2/hr-rfp/products/40344/styles`)
+
   return (
-    <div>
-      <h2>Product Overview</h2>
+    <div className="section">
+      <div className="container">
+        <div className="page-padding">
+          <h2>Product Overview</h2>
+          <p>{styles.product_id}</p>
+        </div>
+      </div>
     </div>
   );
 }
 
 export default ProductOverview
+
+let product = {
+  "id": 40344,
+  "campus": "hr-rfp",
+  "name": "Camo Onesie",
+  "slogan": "Blend in to your crowd",
+  "description": "The So Fatigues will wake you up and fit you in. This high energy camo will have you blending in to even the wildest surroundings.",
+  "category": "Jackets",
+  "default_price": "140.00",
+  "created_at": "2021-08-13T14:38:44.509Z",
+  "updated_at": "2021-08-13T14:38:44.509Z",
+  "features": [
+    {
+      "feature": "Fabric",
+      "value": "Canvas"
+    },
+    {
+      "feature": "Buttons",
+      "value": "Brass"
+    }
+  ]
+}
+
+let styles = {
+  "product_id": "40344",
+  "results": [
+    {
+      "style_id": 240500,
+      "name": "Forest Green & Black",
+      "original_price": "140.00",
+      "sale_price": null,
+      "default?": true,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1501088430049-71c79fa3283e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1534011546717-407bced4d25c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1534011546717-407bced4d25c?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2734&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1549831243-a69a0b3d39e0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1549831243-a69a0b3d39e0?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2775&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1527522883525-97119bfce82d?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1527522883525-97119bfce82d?ixlib=rb-1.2.1&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1556648202-80e751c133da?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1556648202-80e751c133da?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1532543491484-63e29b3c1f5d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1532543491484-63e29b3c1f5d?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
+        }
+      ],
+      "skus": {
+        "1394769": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394770": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394771": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394772": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394773": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394774": {
+          "quantity": 4,
+          "size": "XL"
+        }
+      }
+    },
+    {
+      "style_id": 240501,
+      "name": "Desert Brown & Tan",
+      "original_price": "140.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1533779183510-8f55a55f15c1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1533779183510-8f55a55f15c1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1560567546-4c6dbc16877b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1560567546-4c6dbc16877b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1458253329476-1ebb8593a652?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1458253329476-1ebb8593a652?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1422557379185-474fa15bf770?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1422557379185-474fa15bf770?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1490723286627-4b66e6b2882a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1490723286627-4b66e6b2882a?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1447958272669-9c562446304f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1447958272669-9c562446304f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2800&q=80"
+        }
+      ],
+      "skus": {
+        "1394775": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394776": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394777": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394778": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394779": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394780": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240502,
+      "name": "Ocean Blue & Grey",
+      "original_price": "140.00",
+      "sale_price": "100.00",
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1556304653-cba65c59b3c5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1556304653-cba65c59b3c5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2761&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1544131750-2985d621da30?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1544131750-2985d621da30?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=666&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1557760257-b02421ae77fe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1557760257-b02421ae77fe?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2089&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1551506448-074afa034c05?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1551506448-074afa034c05?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=938&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1556268652-ad74ebb8f1e7?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1556268652-ad74ebb8f1e7?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1557394976-32cc983558ba?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1557394976-32cc983558ba?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1000&q=80"
+        }
+      ],
+      "skus": {
+        "1394781": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394782": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394783": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394784": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394785": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394786": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240503,
+      "name": "Digital Red & Black",
+      "original_price": "140.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1530092376999-2431865aa8df?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1530092376999-2431865aa8df?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2734&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1487174244970-cd18784bb4a4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1487174244970-cd18784bb4a4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1652&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1488554378835-f7acf46e6c98?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1488554378835-f7acf46e6c98?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1486025402772-bc179c8dfb0e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1486025402772-bc179c8dfb0e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1473691955023-da1c49c95c78?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1473691955023-da1c49c95c78?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1517456837005-d757b959ae2b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=60",
+          "url": "https://images.unsplash.com/photo-1517456837005-d757b959ae2b?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=800&q=60"
+        }
+      ],
+      "skus": {
+        "1394787": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394788": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394789": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394790": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394791": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394792": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240504,
+      "name": "Sky Blue & White",
+      "original_price": "140.00",
+      "sale_price": "100.00",
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1448526478325-616f2b15b04e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1448526478325-616f2b15b04e?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1567&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1519098635131-4c8f806d1e82?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1519098635131-4c8f806d1e82?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1483056293146-9eac9521932f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1483056293146-9eac9521932f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=2850&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1515992854631-13de43baeba1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1515992854631-13de43baeba1?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1525141741567-f89ef016dfeb?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1525141741567-f89ef016dfeb?ixlib=rb-1.2.1&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1418985991508-e47386d96a71?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1418985991508-e47386d96a71?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        }
+      ],
+      "skus": {
+        "1394793": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394794": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394795": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394796": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394797": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394798": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    },
+    {
+      "style_id": 240505,
+      "name": "Dark Grey & Black",
+      "original_price": "170.00",
+      "sale_price": null,
+      "default?": false,
+      "photos": [
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1514866726862-0f081731e63f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1514866726862-0f081731e63f?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1519689373023-dd07c7988603?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1519689373023-dd07c7988603?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1506932248762-69d978912b80?ixlib=rb-1.2.1&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1506932248762-69d978912b80?ixlib=rb-1.2.1&auto=format&fit=crop&w=2089&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1535639818669-c059d2f038e6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1535639818669-c059d2f038e6?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=668&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1498098662025-04e60a212db4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1498098662025-04e60a212db4?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1650&q=80"
+        },
+        {
+          "thumbnail_url": "https://images.unsplash.com/photo-1421941027568-40ab08ee5592?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=300&q=80",
+          "url": "https://images.unsplash.com/photo-1421941027568-40ab08ee5592?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1651&q=80"
+        }
+      ],
+      "skus": {
+        "1394799": {
+          "quantity": 8,
+          "size": "XS"
+        },
+        "1394800": {
+          "quantity": 16,
+          "size": "S"
+        },
+        "1394801": {
+          "quantity": 17,
+          "size": "M"
+        },
+        "1394802": {
+          "quantity": 10,
+          "size": "L"
+        },
+        "1394803": {
+          "quantity": 15,
+          "size": "XL"
+        },
+        "1394804": {
+          "quantity": 6,
+          "size": "XXL"
+        }
+      }
+    }
+  ]
+}

--- a/src/components/styles/Styles.css
+++ b/src/components/styles/Styles.css
@@ -1,0 +1,12 @@
+.page-wrapper {}
+
+.container {
+  width: 100%;
+  max-width: 1120px;
+  margin: auto;
+}
+
+.page-padding {
+  padding-left: 32px;
+  padding-right: 32px;
+}


### PR DESCRIPTION
This adds example data to files in the `/examples` folder. We shouldn't need to, but the files can be regenerated with the `gen-examples` script. This also adds Axios as a dependency, and a `.env.example` so we can keep track of what we are storing in our `.env`. 

The example data can be loaded with `require('path/to/the/file')` (aka the old way). 